### PR TITLE
use Object.literal instead of Object.create(null)

### DIFF
--- a/lib/sorted-object.js
+++ b/lib/sorted-object.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = function (input) {
-    var output = Object.create(null);
+    var output = {};
 
     Object.keys(input).sort().forEach(function (key) {
         output[key] = input[key];

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint": "jshint lib && jshint test"
   },
   "devDependencies": {
+    "deep-strict-equal": "^0.1.0",
     "jshint": "~2.4.3",
     "tape": "~2.4.2"
   }

--- a/test/tests.js
+++ b/test/tests.js
@@ -2,6 +2,7 @@
 
 var test = require("tape");
 var sortedObject = require("..");
+var deepStrictEqual = require("deep-strict-equal");
 
 test("does not return the same object", function (t) {
     var input = {};
@@ -15,8 +16,8 @@ test("works for empty objects", function (t) {
     t.end();
 });
 
-test("returns an object with null prototype", function (t) {
-    t.equal(Object.getPrototypeOf(sortedObject({})), null);
+test("returns an object which is deepStrictEqual to target one", function (t) {
+    deepStrictEqual((sortedObject({})), {});
     t.end();
 });
 


### PR DESCRIPTION
The resaon behind this change is that I'm using for sorting JSON objects,
and comparing them with `assert.deepStrictEqual` method (introduced in v4)
and I expected tests to pass. But as far current implmentation
creates objects without prototype it doesn't work this way.
And it seems wrong to me.

So I wanted to start discussion about both approaches.